### PR TITLE
Support Python 3.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,10 +115,14 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.python-version
 
 # Spyder project settings
 .spyderproject
 .spyproject
+
+# VS Code
+.vscode
 
 # Rope project settings
 .ropeproject

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,2 @@
 test:
-	python -m unittest discover
+	pytest

--- a/README.rst
+++ b/README.rst
@@ -45,10 +45,11 @@ Example:
         print(event.name)
         print(event.mask)
 
-        flags = INFlags.CREATE | INFlags.DELETE
-        fs_watcher = Inotify("/home/", watch_flags=flags)
-        fs_watcher.register_handler(INFlags.ALL_FLAGS, my_callback, exclusive=False)
-        fs_watcher.watch()
+    flags = INFlags.CREATE | INFlags.DELETE
+    fs_watcher = Inotify("/home/", watch_flags=flags)
+    fs_watcher.register_handler(INFlags.ALL_FLAGS, my_callback, exclusive=False)
+    fs_watcher.watch()
+
 
 The ``TreeWatcher`` class is provided to recursively watch directories.
 

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 .. image:: https://readthedocs.org/projects/inotify-lite/badge/?version=latest
-	   :target: https://inotify-lite.readthedocs.io/en/latest/?badge=latest
-		    :alt: Documentation Status
+  :target: https://inotify-lite.readthedocs.io/en/latest/?badge=latest
+  :alt: Documentation Status
 
 inotify_lite
 =============
@@ -15,7 +15,7 @@ Requires
 --------
 
 * Linux >= 2.6.13 (or glibc >= 2.5)
-* Python >= 3.8
+* Python >= 3.6
 
 Installation
 ------------
@@ -29,26 +29,26 @@ Usage
 
 To use ``inotify_lite``:
 
-* create an ``Inotify`` instance, passing the name of the files (or directories) you wish to watch;
-* register a handler (or many), a callable of two arguments:
+- Create an ``Inotify`` instance, passing the name of the files (or directories) you wish to watch;
+- Register a handler (or many), a callable of two arguments:
 
-  * an ``Inotify`` instance; and
-  * an ``InotifyEvent`` instance.
+  + an ``Inotify`` instance; and
+  + an ``InotifyEvent`` instance.
 
-* call ``Inotify.read`` to read once, or ``Inotify.watch`` to watch until a keyboard interrupt is received.
+- call ``Inotify.read`` to read once, or ``Inotify.watch`` to watch until a keyboard interrupt is received.
 
 Example:
 
 .. code-block:: python
 
-      def my_callback(_, event):
-	print(event.name)
-	print(event.mask)
+    def my_callback(_, event):
+        print(event.name)
+        print(event.mask)
 
-      flags = INFlags.CREATE | INFlags.DELETE
-      fs_watcher = Inotify("/home/", watch_flags=flags)
-      fs_watcher.register_handler(INFlags.ALL_FLAGS, my_callback, exclusive=False)
-      fs_watcher.watch()
+        flags = INFlags.CREATE | INFlags.DELETE
+        fs_watcher = Inotify("/home/", watch_flags=flags)
+        fs_watcher.register_handler(INFlags.ALL_FLAGS, my_callback, exclusive=False)
+        fs_watcher.watch()
 
 The ``TreeWatcher`` class is provided to recursively watch directories.
 
@@ -73,6 +73,7 @@ License
 
 The project is licensed under GPLv3.
 
+.. _inotify_lite: https://github.com/jams2/inotify_lite
 .. _homepage: https://github.com/jams2/inotify_lite
 .. _documentation: https://inotify-lite.readthedocs.io
 .. _`issue tracker`: https://github.com/jams2/inotify_lite/issues

--- a/inotify_lite/inotify.py
+++ b/inotify_lite/inotify.py
@@ -339,10 +339,8 @@ class Inotify:
             name_len = c_uint32.from_buffer(buf, offset + self.LEN_OFFSET)
             fmt = self.get_event_struct_format(name_len.value)
             obj_size = calcsize(fmt)
-            segment = buf[offset : offset + obj_size]   # NOQA: E203
-            self._handle_event(
-                InotifyEvent.from_struct(unpack(fmt, segment))
-            )
+            segment = buf[offset : offset + obj_size]  # NOQA: E203
+            self._handle_event(InotifyEvent.from_struct(unpack(fmt, segment)))
             offset += obj_size
         return bytes_read
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = --flake8 --mypy
+testpaths = tests inotify_lite
+flake8-max-line-length = 120

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+ignore = W503

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("README.rst", "r") as fh:
         author_email="public@elysee-munn.family",
         description="Linux inotify wrapper",
         long_description=long_description,
-        long_description_content_type="text/markdown",
+        long_description_content_type="text/restructured",
         url="https://github.com/jams2/inotify_lite",
         packages=setuptools.find_packages(),
         classifiers=[
@@ -19,5 +19,8 @@ with open("README.rst", "r") as fh:
             "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
             "Operating System :: POSIX :: Linux",
         ],
-        python_requires=">=3.8",
+        python_requires=">=3.6",
+        extras_require={
+            'dev': ['pytest-mypy', 'pytest-flake8']
+        }
     )

--- a/tests/test_inotify.py
+++ b/tests/test_inotify.py
@@ -1,4 +1,3 @@
-import unittest
 import os
 from functools import wraps
 from typing import Callable
@@ -30,9 +29,9 @@ class CallCountWrapper:
         self.func(*args, **kwargs)
 
 
-class TestInotify(unittest.TestCase):
+class TestInotify:
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.tmpfile = None
 
     @with_tempfile
@@ -44,7 +43,7 @@ class TestInotify(unittest.TestCase):
         fd = os.open(self.tmpfile.name, os.O_RDONLY)
         os.close(fd)
         watcher.read()
-        self.assertEqual(1, handler.counter)
+        assert handler.counter == 1
         watcher.teardown()
 
     @with_tempfile
@@ -56,5 +55,5 @@ class TestInotify(unittest.TestCase):
         fd = os.open(self.tmpfile.name, os.O_RDONLY)
         os.close(fd)
         watcher.read()
-        self.assertEqual(1, handler.counter)
+        assert handler.counter == 1
         watcher.teardown()


### PR DESCRIPTION
Follow discussion in #2.

There is no changes that need to be added to test cases. All current test cases run fine in Python 3.6. 

However, I change test runner to Pytest, so that I can integrate Flake8, MyPy check into one run.

Code are also formatted with Black.